### PR TITLE
Linux hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A DICOM tag reference can be found [here](https://dicom.innolitics.com/ciods/cr-
 
 ### Requirements
 
-Since we run this tool on MacOS, it requires docker (see below)
+Since we run this tool on macOS, it requires docker (see below). Although we use macOS, community users have also reported running it successfully on Ubuntu Linux (but you must ensure you are using JDK v.8 and JRE v.8: on Ubuntu use `update-alternatives` to select your Java version).
 
 ### Installation
 


### PR DESCRIPTION
Tested working on Ubuntu 21.10
Docker 1.5-2
Ant 1.10.9-4
openjdk version "1.8.0_312"
javac 1.8.0_312

Hints provided: this would have significantly smoothed my install!